### PR TITLE
Fix service worker caching paths

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,7 @@
 const CACHE_NAME = 'thomas-schwabauer-v1';
 const urlsToCache = [
   '/',
-  '/static/css/main.css',
-  '/static/js/main.js',
-  '/me-laptop.png',
+  '/me-laptop.webp',
   '/favicon.ico',
 ];
 


### PR DESCRIPTION
Fix service worker caching by updating incorrect asset paths.

The service worker was attempting to cache `/me-laptop.png` instead of the correct `/me-laptop.webp`. Additionally, it was trying to cache `/static/css/main.css` and `/static/js/main.js`, which are incorrect for Next.js applications where assets are served from `/_next/static/` with hashed filenames. These corrections ensure the service worker caches the actual resources.